### PR TITLE
Fix #1 - Added broadcast ability from shared/worker to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,19 @@ One way shared/worker async bindings to simply export bindings, as callbacks, fr
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script type="module">
-    import { SharedWorker, Worker, proxied } from 'accordant/main';
-    const sw = new SharedWorker('./shared-worker.js');
-    const w = new Worker('./worker.js');
+    import { SharedWorker, Worker, broadcast, proxied } from 'accordant/main';
+    const sw = new SharedWorker('./shared-worker.js', {
+      // invoked per each broadcast
+      [broadcast](...args) {
+        console.log('SharedWorker', ...args);
+      }
+    });
+    const w = new Worker('./worker.js', {
+      // invoked per each broadcast
+      [broadcast](...args) {
+        console.log('Worker', ...args);
+      }
+    });
     // both workers export a `random` method
     console.log(await sw.random());
     console.log(await w.random());
@@ -23,19 +33,35 @@ One way shared/worker async bindings to simply export bindings, as callbacks, fr
 ```
 
 ```js
-// shared-worker.js
-import exports from 'accordant/shared-worker';
+// shared-worker.js - multiple ports
+import { broadcast, exports } from 'accordant/shared-worker';
+
+const sameValue = Math.random();
 
 exports({
-  random: () => ({ SharedWorker: Math.random() }),
+  random: () => ({ SharedWorker: sameValue }),
+});
+
+let ports = 0;
+
+// using the broadcast utility to notify all ports
+addEventListener('port:connected', () => {
+  broadcast('connected ports', ++ports);
+});
+
+addEventListener('port:disconnected', () => {
+  broadcast('disconnected port, now there are', --ports, 'ports');
 });
 ```
 
 ```js
-// worker.js
-import exports from 'accordant/worker';
+// worker.js - single "port"
+import { broadcast, exports } from 'accordant/worker';
 
 exports({
   random: () => ({ Worker: Math.random() }),
 });
+
+// just invoke the broadcast symbol option
+broadcast('current', 'worker');
 ```

--- a/src/accordant.js
+++ b/src/accordant.js
@@ -1,4 +1,4 @@
-import { isArray, stop } from './utils.js';
+import { broadcast, isArray, stop } from './utils.js';
 import Transferable from './transferable.js';
 
 class EventHandler {
@@ -6,6 +6,9 @@ class EventHandler {
   #promise;
   constructor(promise) {
     this.#promise = promise;
+  }
+  get [broadcast]() {
+    return this.#channel;
   }
   async handleEvent(event) {
     const { currentTarget, data } = event;
@@ -46,7 +49,8 @@ class EventHandler {
   }
 }
 
-export default (port, promise) => port.addEventListener(
-  'message',
-  new EventHandler(promise),
-);
+export default (port, promise) => {
+  const eh = new EventHandler(promise);
+  port.addEventListener('message', eh);
+  return eh;
+};

--- a/src/shared.js
+++ b/src/shared.js
@@ -1,15 +1,35 @@
-import { assign, withResolvers } from './utils.js';
+import { assign, broadcast , forIt, withResolvers } from './utils.js';
 import accordant from './accordant.js';
 
 const { promise, resolve } = withResolvers();
 
 const ffi = {};
+const references = new Map;
+const notify = connected => {
+  const type = `port:${connected ? 'connected' : 'disconnected'}`;
+  dispatchEvent(new Event(type));
+}
+const fr = new FinalizationRegistry(wr => {
+  references.delete(wr);
+  notify(false);
+});
 
-addEventListener('connect', async ({ ports }) => {
+const $broadcast = async (...args) => {
+  for (const [wr, eh] of [...references]) {
+    while (!eh[broadcast]) await forIt();
+    wr.deref()?.postMessage([eh[broadcast], 0, eh[broadcast], args]);
+  }
+};
+
+addEventListener('connect', ({ ports }) => {
   for (const port of ports) {
-    accordant(port, promise);
+    const wr = new WeakRef(port);
+    fr.register(port, wr);
+    references.set(wr, accordant(port, promise));
     port.start();
+    promise.then(() => notify(true));
   }
 });
 
-export default bindings => resolve(assign(ffi, bindings));
+const exports = bindings => resolve(assign(ffi, bindings));
+export { $broadcast as broadcast, exports };

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,9 +2,13 @@ const { isArray } = Array;
 const { assign } = Object;
 export { assign, isArray };
 
+export const broadcast = Symbol();
+
 export const stop = event => {
   event.stopImmediatePropagation();
   event.preventDefault();
 };
+
+export const forIt = () => new Promise($ => setTimeout($, 0));
 
 export const withResolvers = () => Promise.withResolvers();

--- a/src/worker.js
+++ b/src/worker.js
@@ -1,10 +1,16 @@
-import { assign, withResolvers } from './utils.js';
+import { assign, broadcast, forIt, withResolvers } from './utils.js';
 import accordant from './accordant.js';
 
 const { promise, resolve } = withResolvers();
 
 const ffi = {};
 
-accordant(self, promise);
+const eh = accordant(self, promise);
 
-export default bindings => resolve(assign(ffi, bindings));
+const $broadcast = async (...args) => {
+  while (!eh[broadcast]) await forIt();
+  postMessage([eh[broadcast], 0, eh[broadcast], args]);
+};
+
+const exports = bindings => resolve(assign(ffi, bindings));
+export { $broadcast as broadcast, exports };

--- a/test/index.html
+++ b/test/index.html
@@ -4,13 +4,21 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <script type="module">
-    import { SharedWorker, Worker, proxied } from '../src/main.js';
-    const sw = new SharedWorker('./shared-worker.js');
-    const w = new Worker('./worker.js');
+    import { SharedWorker, Worker, broadcast, proxied } from '../src/main.js';
+    const sw = new SharedWorker('./shared-worker.js', {
+      [broadcast](...args) {
+        console.log('SharedWorker', ...args);
+      }
+    });
+    const w = new Worker('./worker.js', {
+      [broadcast](...args) {
+        console.log('Worker', ...args);
+      }
+    });
     console.log(await sw.random());
-    console.log(await w.random());
-    console.log(proxied(sw));
-    console.log(proxied(w));
+    console.log(await w.random(), await w.multiple());
+    // proxied(sw).close();
+    // proxied(w).terminate();
   </script>
 </head>
 </html>

--- a/test/shared-worker.js
+++ b/test/shared-worker.js
@@ -1,5 +1,19 @@
-import exports from '../src/shared.js';
+import { broadcast, exports } from '../src/shared.js';
+
+const SharedWorker = Math.random();
+let ports = 0;
 
 exports({
-  random: () => ({ SharedWorker: Math.random() }),
+  random: () => ({ SharedWorker }),
+});
+
+
+addEventListener('port:connected', ({ type }) => {
+  ports++;
+  broadcast(type, ports);
+});
+
+addEventListener('port:disconnected', ({ type }) => {
+  ports--;
+  broadcast(type, ports);
 });

--- a/test/worker.js
+++ b/test/worker.js
@@ -1,9 +1,11 @@
-import exports from '../src/worker.js';
+import { broadcast, exports } from '../src/worker.js';
 
 exports({
-  multiple: 'bindings',
+  multiple: () => 'bindings',
 });
 
 exports({
   random: () => ({ Worker: Math.random() }),
 });
+
+broadcast('worker:connected');


### PR DESCRIPTION
This MR goal is to provide at least a way to broadcast from the shared/worker to the main thread with ease, by accepting a single `broadcast` option (as symbol) so that part of https://github.com/WebReflection/accordant/issues/1 can be addressed.

What is missing in here is the ability *from* *SharedWorker* only to broadcast to all ports but the current one ... but with current logic it is still possible to orchestrate a *broadcast* filter through some little orchestration, without complicating too much the broadcast logic in general.

As example, if the `broadcast` option accepts a unique identifier as first argument, or as part of the data that's being sent, it could filter itself by such ID and decide if it should react or not to that event.

Exposing a `broadcast` counter-method through the shared worker would be fairly trivial as `exports({ broadcast })` would work too, making the library author in charge of such feature.